### PR TITLE
Fix path to jslint submodule

### DIFF
--- a/lib/jslint.js
+++ b/lib/jslint.js
@@ -7,7 +7,7 @@ var vm = require('vm');
 var fs = require('fs');
 
 /*jslint nomen:true, stupid:true*/
-var JSLINT_PATH = path.join(__dirname, '../JSLint/jslint.js');
+var JSLINT_PATH = path.join(__dirname, '../jslint/jslint.js');
 
 var ctx = vm.createContext();
 vm.runInContext(fs.readFileSync(JSLINT_PATH, 'utf-8'), ctx);

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 		"grunt": "~0.3.11",
 		"entities": "~0.1.1",
 		"clone": "~0.1.1",
-		"underscore": "1.4.x"
+		"underscore": "1.4.x",
+		"colors": "~0.6.0-1"
 	},
 	"devDependencies": {
 		"grunt-vows": "~0.2.1"


### PR DESCRIPTION
I've added a missing dependency and fixed the jslint path, however when I run "grunt vows" I still see:

``` bash
$ grunt vows
Running "vows:all" (vows) task
<WARN> Task "vows:all" failed. Use --force to continue. </WARN>

Aborted due to warnings.
```

Any advice on this?
