### PR TITLE
Escape values going into XML files where they may contain code samples.

### DIFF
--- a/lib/reports.js
+++ b/lib/reports.js
@@ -24,6 +24,18 @@ var underscore = (function () {
 
 var templates = require('./templates/index.js');
 
+/**
+ * Escapes the given value so that it can be placed in an XML file.
+ * @return the escaped value
+ */
+function escapeForXml(value) {
+	'use strict';
+
+	return value.replace(/&/g, '&amp;')
+			.replace(/</g, '&lt;')
+			.replace(/>/g, '&gt;')
+			.replace(/"/g, '&quot;');
+}
 
 /**
  * Produce the standard grunt-jslint report
@@ -63,12 +75,12 @@ function junitXml(report) {
 		report.files[file].forEach(function (failure) {
 			failures.push({
 				id: filename + ':' + failure.line + ':' + (failure.character || ''),
-				message: [
+				message: escapeForXml([
 					failure.line + ':',
 					failure.character ? failure.character + ':' : '',
 					' ',
 					failure.reason || 'Unused variable `' + failure.name + '`'
-				].join('')
+				].join(''))
 			});
 		});
 
@@ -99,10 +111,19 @@ function jslintXml(report) {
 		files = [];
 
 	keys.forEach(function (file) {
+		var issues = report.files[file];
+		underscore.each(issues, function (issue) {
+			if (issue.reason) {
+				issue.reason = escapeForXml(issue.reason);
+			}
+			if (issue.evidence) {
+				issue.evidence = escapeForXml(issue.evidence);
+			}
+		});
 
 		files.push({
 			'name': file,
-			'issues': report.files[file]
+			'issues': issues
 		});
 
 	});


### PR DESCRIPTION
In particular I found that in the jslintXml report that the "evidence" field contained a good portion of code, and therefore some characters that need to be escaped for the XML report.

I've also escaped the message fields as I'm not sure exactly what values they can take.
