### PR TITLE
Use realpaths for jslint xml reports

### DIFF
--- a/lib/reports.js
+++ b/lib/reports.js
@@ -1,6 +1,8 @@
-/*jslint node:true*/
+/*jslint node:true, stupid: true*/
 
 require('./colors.js');
+
+var fs = require('fs');
 
 /**
  * Grab the `underscore/lodash` util from grunt.  The `util` namespace changed
@@ -101,7 +103,7 @@ function jslintXml(report) {
 	keys.forEach(function (file) {
 
 		files.push({
-			'name': file,
+			'name': fs.realpathSync(file),
 			'issues': report.files[file]
 		});
 


### PR DESCRIPTION
Not having real paths prevents Violation reports in Jenkins from showing annotated code views.
