### PR TITLE
Strip color codes on --no-color

### DIFF
--- a/tasks/jslint.js
+++ b/tasks/jslint.js
@@ -86,6 +86,10 @@ module.exports = function (grunt) {
 				grunt.file.write(options.checkstyle, reports.checkstyle(report));
 			}
 
+			if (grunt.option('no-color')) {
+				template = grunt.log.uncolor(template);
+			}
+
 			grunt.log.write(template);
 
 			if (report.failures && options.failOnError) {


### PR DESCRIPTION
Strip color codes if `--no-color` is passed to grunt-jslint.

Closes GH-14
