### PR TITLE
Adding an additional multi task

### DIFF
--- a/tasks/jslint.js
+++ b/tasks/jslint.js
@@ -14,27 +14,18 @@ var reports = require('../lib/reports'),
   runner = require('../lib/runner');
 
 module.exports = function (grunt) {
+
   /**
-   * Grabs a config option from the jslint namespace
+   * Takes the config / options from the single or multi task
+   * and does the body of the work
    *
-   * @param  {String} option The option/configuration key
-   * @return {Mixed|Any}     The key's value
+   * @param {Function} next           async handler
+   * @param {Array} files             src files
+   * @param {Array} excludedFiles     files to exclude
+   * @param {Object} options          The option key-value array
+   * @param {Object} directives       JSLint directives
    */
-  function conf(option) {
-    return grunt.config('jslint.' + option);
-  }
-
-  /**
-   * The task
-   */
-  grunt.registerTask('jslint', 'Validate JavaScript files with JSLint', function () {
-
-    var next = this.async(),
-      files = conf('files'),
-      excludedFiles = conf('exclude') || [],
-      options = conf('options') || {},
-      directives = conf('directives') || {};
-
+  function task(next, files, excludedFiles, options, directives) {
     if (!files) {
       grunt.log.error('NO FILES?!?');
       return false;
@@ -43,7 +34,6 @@ module.exports = function (grunt) {
     if (options.failOnError === undefined) {
       options.failOnError = true;
     }
-
     excludedFiles = grunt.file.expand(excludedFiles);
 
     files = grunt.file
@@ -97,7 +87,43 @@ module.exports = function (grunt) {
         next(true);
       }
     });
+  }
 
+  /**
+   * Grabs a config option from the jslint namespace
+   *
+   * @param  {String} option The option/configuration key
+   * @return {Mixed|Any}     The key's value
+   */
+  function conf(option) {
+    return grunt.config('jslint.' + option);
+  }
+
+  /**
+   * The task
+   */
+  grunt.registerTask('jslint', 'Validate JavaScript files with JSLint', function () {
+
+    var next = this.async(),
+      files = conf('files'),
+      excludedFiles = conf('exclude') || [],
+      options = conf('options') || {},
+      directives = conf('directives') || {};
+
+    task(next, files, excludedFiles, options, directives);
+  });
+
+  /**
+   * The task
+   */
+  grunt.registerMultiTask('jslintm', 'Validate JavaScript files with JSLint', function () {
+    var next = this.async(),
+      files = this.filesSrc,
+      excludedFiles = this.data.exclude || [],
+      options = this.data.options || {},
+      directives = this.data.directives || {};
+
+    task(next, files, excludedFiles, options, directives);
   });
 
 };


### PR DESCRIPTION
I'm working on a node application where the client and server side javascript need slightly different JSLint directives, for example client side has browser:true, where server side has node:true and sloppy:true.

This PR adds multiTask support to grunt-jslint so that I can easily setup two separate tasks with different directives to lint each section of JavaScript.

There doesn't seem to be a way to upgrade a standard single task to support multi task, so for the sake of backwards compatibility, I've left the old task alone and added a new task called "jslintm".

This way all old jslint tasks carry on functioning, but anyone who needs to do split linting like me can add or upgrade their tasks.
