### PR TITLE
Bump jslint version for es6 support.

### DIFF
--- a/lib/jslint.js
+++ b/lib/jslint.js
@@ -179,7 +179,7 @@ jslint.validate = function (file, opts, cb) {
 
     JSLINT(source, directives);
 
-    var violations = JSLINT.errors;
+    var violations = JSLINT.errors || [];
     var res = [];
 
     violations.forEach(function (violation) {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "jslint": "~0.8.1"
+    "jslint": "^0.9.6"
   },
   "devDependencies": {
     "better-assert": "~1.0.0",


### PR DESCRIPTION
My project is trying out es6.

I set my edition to es6, and found out that grunt-jslint is out of date with respect to npm jslint.  So I bumped the version in this project and fixed an 'undefined' error in lib/jslint.js

I've tested it out on my own project and it works fine.
